### PR TITLE
[PDR-1496] Update Notebook with alternate db connection.

### DIFF
--- a/PDR/Instruction - How to connect to PDR PostgreSQL.ipynb
+++ b/PDR/Instruction - How to connect to PDR PostgreSQL.ipynb
@@ -114,7 +114,7 @@
   },
   {
    "cell_type": "code",
-   "execution_count": 1,
+   "execution_count": 13,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-11-19T14:13:21.162186Z",
@@ -132,14 +132,34 @@
     "\n",
     "username = 'username'\n",
     "password = 'password'\n",
-    "port = 7005  # 7005 = read-only access\n",
+    "port = '7005'  # 7005 = read-only access\n",
     "\n",
     "db_conn = create_engine(f'postgresql://{username}:{password}@localhost:{port}/drc')"
    ]
   },
   {
    "cell_type": "code",
-   "execution_count": 2,
+   "execution_count": 14,
+   "metadata": {},
+   "outputs": [],
+   "source": [
+    "#### An alternative method - if you have an older version of sqlalchemy and can't update the package, the below method will work without requiring support for fillable queries.\n"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 15,
+   "metadata": {
+    "scrolled": true
+   },
+   "outputs": [],
+   "source": [
+    "db_conn = create_engine('postgresql://'+username+':'+password+'@localhost:'+port+'/drc')"
+   ]
+  },
+  {
+   "cell_type": "code",
+   "execution_count": 16,
    "metadata": {
     "ExecuteTime": {
      "end_time": "2021-11-15T22:54:45.029564Z",
@@ -152,11 +172,11 @@
      "output_type": "stream",
      "text": [
       "    total enrollment_status\n",
-      "0  310481  CORE_PARTICIPANT\n",
-      "1  139156        REGISTERED\n",
-      "2   71547   FULLY_CONSENTED\n",
-      "3   41680       PARTICIPANT\n",
-      "4   14083     CORE_MINUS_PM\n"
+      "0  399666  CORE_PARTICIPANT\n",
+      "1  268269        REGISTERED\n",
+      "2  103452   FULLY_CONSENTED\n",
+      "3   61941       PARTICIPANT\n",
+      "4    9975     CORE_MINUS_PM\n"
      ]
     }
    ],
@@ -232,9 +252,9 @@
  "metadata": {
   "hide_input": false,
   "kernelspec": {
-   "display_name": "PDR Virtual Env",
+   "display_name": "Python 3 (ipykernel)",
    "language": "python",
-   "name": "venv"
+   "name": "python3"
   },
   "language_info": {
    "codemirror_mode": {
@@ -246,7 +266,7 @@
    "name": "python",
    "nbconvert_exporter": "python",
    "pygments_lexer": "ipython3",
-   "version": "3.9.7"
+   "version": "3.9.12"
   },
   "nbTranslate": {
    "displayLangs": [


### PR DESCRIPTION
Some users from NIH are having difficulty following these instructions due to an outdated sqlalchemy package that they can't update.  This uses string concatenation instead of parameterized queries, which should work for both the 1.3.X and 1.4.X versions of sqlalchemy.